### PR TITLE
Addition of an event that is raised pre save on the XmlDoc object

### DIFF
--- a/jumps.umbraco.usync/helpers/XmlDoc.cs
+++ b/jumps.umbraco.usync/helpers/XmlDoc.cs
@@ -18,9 +18,14 @@ namespace jumps.umbraco.usync.helpers
     /// xml is consistantly created, and put in some
     /// form of logical place. 
     /// </summary>
+
+    public delegate void XmlDocPreSaveEventHandler(XmlDocSaveEventArgs e);
+
     public class XmlDoc
     {
         private static bool _versions = false;  
+
+        public static event XmlDocPreSaveEventHandler preSave;
 
         static XmlDoc()
         {
@@ -69,7 +74,7 @@ namespace jumps.umbraco.usync.helpers
                     File.Delete(savePath);
                 }
             }
-
+            onPreSave(new XmlDocSaveEventArgs(savePath));
             doc.Save(savePath) ; 
         }
 
@@ -172,6 +177,13 @@ namespace jumps.umbraco.usync.helpers
         {
             return type.Substring(type.LastIndexOf('.') + 1);
         }
-        
+
+        public static void onPreSave(XmlDocSaveEventArgs e)
+        {
+            if (preSave != null)
+            {
+                preSave(e);
+            }
+        }
     }
 }

--- a/jumps.umbraco.usync/helpers/XmlDoc.cs
+++ b/jumps.umbraco.usync/helpers/XmlDoc.cs
@@ -19,13 +19,14 @@ namespace jumps.umbraco.usync.helpers
     /// form of logical place. 
     /// </summary>
 
-    public delegate void XmlDocPreSaveEventHandler(XmlDocSaveEventArgs e);
+    public delegate void XmlDocPreModifiedEventHandler(XmlDocFileEventArgs e);
 
     public class XmlDoc
     {
         private static bool _versions = false;  
 
-        public static event XmlDocPreSaveEventHandler preSave;
+        public static event XmlDocPreModifiedEventHandler preSave;
+        public static event XmlDocPreModifiedEventHandler preDelete;
 
         static XmlDoc()
         {
@@ -74,7 +75,7 @@ namespace jumps.umbraco.usync.helpers
                     File.Delete(savePath);
                 }
             }
-            onPreSave(new XmlDocSaveEventArgs(savePath));
+            OnPreSave(new XmlDocFileEventArgs(savePath));
             doc.Save(savePath) ; 
         }
 
@@ -130,6 +131,7 @@ namespace jumps.umbraco.usync.helpers
 
                     // 
                     File.Copy(currentFile, archiveFile);
+                    OnPreDelete(new XmlDocFileEventArgs(currentFile));
                     File.Delete(currentFile);
                 }
             }
@@ -178,11 +180,19 @@ namespace jumps.umbraco.usync.helpers
             return type.Substring(type.LastIndexOf('.') + 1);
         }
 
-        public static void onPreSave(XmlDocSaveEventArgs e)
+        public static void OnPreSave(XmlDocFileEventArgs e)
         {
             if (preSave != null)
             {
                 preSave(e);
+            }
+        }
+
+        public static void OnPreDelete(XmlDocFileEventArgs e)
+        {
+            if (preDelete != null)
+            {
+                preDelete(e);
             }
         }
     }

--- a/jumps.umbraco.usync/helpers/XmlDocFileEventArgs.cs
+++ b/jumps.umbraco.usync/helpers/XmlDocFileEventArgs.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace jumps.umbraco.usync.helpers
 {
-    public class XmlDocSaveEventArgs : EventArgs
+    public class XmlDocFileEventArgs : EventArgs
     {
-        private string _path;
+        private readonly string _path;
 
-        public XmlDocSaveEventArgs(string path)
+        public XmlDocFileEventArgs(string path)
         {
             _path = path;
         }

--- a/jumps.umbraco.usync/helpers/XmlDocSaveEventArgs.cs
+++ b/jumps.umbraco.usync/helpers/XmlDocSaveEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace jumps.umbraco.usync.helpers
+{
+    public class XmlDocSaveEventArgs : EventArgs
+    {
+        private string _path;
+
+        public XmlDocSaveEventArgs(string path)
+        {
+            _path = path;
+        }
+
+        public string Path
+        {
+            get { return _path; }
+        }
+
+    }
+}

--- a/jumps.umbraco.usync/jumps.umbraco.usync_4.csproj
+++ b/jumps.umbraco.usync/jumps.umbraco.usync_4.csproj
@@ -81,6 +81,7 @@
     <Compile Include="helpers\uSyncIO.cs" />
     <Compile Include="helpers\uSyncLog.cs" />
     <Compile Include="helpers\XmlDoc.cs" />
+    <Compile Include="helpers\XmlDocSaveEventArgs.cs" />
     <Compile Include="SyncDataType.cs" />
     <Compile Include="SyncDictionary.cs" />
     <Compile Include="SyncDocType.cs" />

--- a/jumps.umbraco.usync/jumps.umbraco.usync_4.csproj
+++ b/jumps.umbraco.usync/jumps.umbraco.usync_4.csproj
@@ -81,7 +81,7 @@
     <Compile Include="helpers\uSyncIO.cs" />
     <Compile Include="helpers\uSyncLog.cs" />
     <Compile Include="helpers\XmlDoc.cs" />
-    <Compile Include="helpers\XmlDocSaveEventArgs.cs" />
+    <Compile Include="helpers\XmlDocFileEventArgs.cs" />
     <Compile Include="SyncDataType.cs" />
     <Compile Include="SyncDictionary.cs" />
     <Compile Include="SyncDocType.cs" />


### PR DESCRIPTION
I have written a helper class to help us use uSync in conjunction with TFS2010.

When the file was trying to be saved, TFS would complain that it wasn't checked out, so this event tells me that the file is going to be saved, and I can then force a checkout in code. 
