### PR TITLE
Check umbraco config status

### DIFF
--- a/jumps.umbraco.usync/uSync.cs
+++ b/jumps.umbraco.usync/uSync.cs
@@ -44,6 +44,8 @@ namespace jumps.umbraco.usync
 
         private bool _docTypeSaveWorks = false; 
 
+        private readonly bool _umbracoIsConfigured = ConfigurationManager.AppSettings["umbracoConfigurationStatus"].Trim() != "";
+
         /// <summary>
         /// do the stuff we do when we start, using locks, and flags so
         /// we only do the stuff once..
@@ -222,6 +224,12 @@ namespace jumps.umbraco.usync
         private void RunSync()
         {
             helpers.uSyncLog.InfoLog("uSync Starting - for detailed debug info. set priority to 'Debug' in log4net.config file"); 
+
+            if (!_umbracoIsConfigured)
+            {
+                helpers.uSyncLog.InfoLog("Umbraco not configured, aborting sync");
+                return;
+            }
 
             // Save Everything to disk.
             // only done first time or when write = true           


### PR DESCRIPTION
Fixes SQLException issues when targetting a site with uSync at a blank db. With this change it is possible to first go through the /install process, then uSync runs as normal.
