### PR TITLE
Definitions are reset to "original" definition when multiple definitions of a data type.

### DIFF
--- a/jumps.umbraco.usync/SyncProviders/ContentTypeSyncProvider.cs
+++ b/jumps.umbraco.usync/SyncProviders/ContentTypeSyncProvider.cs
@@ -225,7 +225,13 @@ namespace jumps.umbraco.usync.SyncProviders
 
                     var dataTypeDefintion = _dataTypeService.GetDataTypeDefinitionById(dataTypeDefinitionId);
 
-                    if (dataTypeDefintion == null || dataTypeDefintion.ControlId != legacyEditorId)
+                    if (dataTypeDefintion != null && 
+                        dataTypeDefintion.Key == dataTypeDefinitionId &&
+                        dataTypeDefintion.PropertyEditorAlias == propertyEditorAlias)
+                    {
+                        // All good..
+                    }
+                    else if (dataTypeDefintion == null || dataTypeDefintion.ControlId != legacyEditorId)
                     {
 #if UMBRACO7
                         var dataTypeDefintions = legacyEditorId != Guid.Empty


### PR DESCRIPTION
Can't have multiple definitions on same "new" data type with current logic.
I know you're in development, but I can't help myself from going edge.

No rush pulling, I'll run on my fork and update when and if.
Feel free to kill the PR and make it "good" instead. ;)
