### PR TITLE
Minor nullreference fix for datatypes

### DIFF
--- a/jumps.umbraco.usync/SyncDataTypesV7.cs
+++ b/jumps.umbraco.usync/SyncDataTypesV7.cs
@@ -105,7 +105,7 @@ namespace jumps.umbraco.usync
             {
                 var prevalue = new XElement("PreValue");
                 prevalue.Add(new XAttribute("Id", pv.Value.Id));
-                prevalue.Add(new XAttribute("Value", pv.Value.Value));
+                prevalue.Add(new XAttribute("Value", pv.Value.Value ?? ""));
                 prevalue.Add(new XAttribute("Alias", pv.Key));
                 prevalue.Add(new XAttribute("SortOrder", sort));
                 prevalues.Add(prevalue);


### PR DESCRIPTION
Some datatypes have a null as prevalue value. new XAttribute throws nullreference exception.
You should probably add an XAttribute factory replacing null values with empty string to avoid such cases.
