### PR TITLE
Corrected the file path

### DIFF
--- a/jumps.umbraco.usync/SyncTemplate.cs
+++ b/jumps.umbraco.usync/SyncTemplate.cs
@@ -222,7 +222,7 @@ namespace jumps.umbraco.usync
             if (!uSync.EventsPaused)
             {
                 LogHelper.Info<uSync>("Template after delete");
-                XmlDoc.ArchiveFile("Template", XmlDoc.ScrubFile(sender.Alias));
+                XmlDoc.ArchiveFile("Template", XmlDoc.ScrubFile(sender.Alias), XmlDoc.ScrubFile(sender.Alias));
             }
         }
 


### PR DESCRIPTION
We identified an issue with uSync where it didn't delete template.config files after deleting templates from the CMS. 

The cause of the issue is that the path to the template config file was not correctly set, where it's supposed to be {RootPath}\uSync\Template\{TemplateName}\{TemplateName}.config, but it was trying to delete {RootPath}\uSync\Template\{TemplateName}.config instead.

So calling the method ArchiveFile(string type, string path, string name) in Delete event has resolved the problem.
