### PR TITLE
Fixed template archiving issue

### DIFF
--- a/jumps.umbraco.usync/SyncTemplate.cs
+++ b/jumps.umbraco.usync/SyncTemplate.cs
@@ -222,9 +222,7 @@ namespace jumps.umbraco.usync
             if (!uSync.EventsPaused)
             {
                 LogHelper.Info<uSync>("Template after delete");
-
-                var template = ApplicationContext.Current.Services.FileService.GetTemplate(sender.Id);
-                XmlDoc.ArchiveFile("Template", GetTemplatePath(template), XmlDoc.ScrubFile(template.Alias));
+                XmlDoc.ArchiveFile("Template", GetDocPath(sender), XmlDoc.ScrubFile(sender.Alias));
             }
         }
 


### PR DESCRIPTION
Hi Kevin

``` c#
var template = ApplicationContext.Current.Services.FileService.GetTemplate(sender.Id);
```

would return null as the template would have already been deleted from Umbraco in an after delete event.
